### PR TITLE
Add node process unhandledRejection handler to CommonAppModule

### DIFF
--- a/RELEASE_LETTERS.md
+++ b/RELEASE_LETTERS.md
@@ -1,5 +1,9 @@
 <h1>Release letter for sprinting-retail-common</h1>
 
+<h2>Release letter for version 3.0.2</h2>
+
+- Adding a default process-level handler for unhandledRejection event, preventing server crash in case of unawaited promises. This handler will log an error in case of such events
+
 <h2>Release letter for version 3.0.1</h2>
 
 - Adding extra convenience method to logException with less cluttered code

--- a/build-local-bifrostnest.sh
+++ b/build-local-bifrostnest.sh
@@ -1,1 +1,1 @@
- tsc --emitDecoratorMetadata && npm pack && cd ../bifrostbackend2/BifrostNest && npm install ../../sprinting-retail-common/sprinting-retail-common-3.0.1.tgz && cd ../../sprinting-retail-common
+ tsc --emitDecoratorMetadata && npm pack && cd ../bifrostbackend2/BifrostNest && npm install ../../sprinting-retail-common/sprinting-retail-common-3.0.2.tgz && cd ../../sprinting-retail-common

--- a/build-local-personservice.sh
+++ b/build-local-personservice.sh
@@ -1,1 +1,1 @@
- tsc --emitDecoratorMetadata && npm pack && cd ../sprinting_personservice/PersonServiceApi && npm install ../../sprinting-retail-common/sprinting-retail-common-3.0.0.tgz && cd ../../sprinting-retail-common
+ tsc --emitDecoratorMetadata && npm pack && cd ../sprinting_personservice/PersonServiceApi && npm install ../../sprinting-retail-common/sprinting-retail-common-3.0.2.tgz && cd ../../sprinting-retail-common

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "sprinting-retail-common",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "Error handling and logging with APM",
   "contributors": [
     "Nairi Abgaryan",
-    "Nikola Schou"
+    "Nikola Schou",
+    "Szabolcs Nagy"
   ],
   "license": "MIT",
   "keywords": [

--- a/src/appModule/CommonAppModule.ts
+++ b/src/appModule/CommonAppModule.ts
@@ -2,11 +2,14 @@ import { DynamicModule, Global, Module, Scope } from "@nestjs/common"
 import { ConfigModule } from "../config/ConfigModule"
 import { LoggerModule } from "../logger/LoggerModule"
 import { APP_FILTER, HttpAdapterHost, REQUEST } from "@nestjs/core"
+import { LoggerConfig } from "../logger/LoggerConfig"
 import { LoggerService } from "../logger/LoggerService"
 import TenantContext from "../context/TenantContext"
+import { ServerException } from "../errorHandling/exceptions/ServerException"
 import { GlobalErrorFilter } from "../errorHandling/GlobalErrorFilter"
 import { TenantContextFactory } from "../context/TenantContextFactory"
 import { RetailCommonConfig } from "../config/interface/RetailCommonConfig"
+import { ConfigMapper } from "../config/legacyInterfaces/ConfigMapper"
 import { LoadBalancingTimeoutBootstrap } from "../helpers/LoadBalancingTimeoutBootstrap"
 import { RetailCommonConfigProvider } from "../config/RetailCommonConfigProvider"
 
@@ -20,6 +23,22 @@ import { RetailCommonConfigProvider } from "../config/RetailCommonConfigProvider
 export class CommonAppModule {
   static forRoot(config: RetailCommonConfig): DynamicModule {
     const configProvider = new RetailCommonConfigProvider(config)
+    const loggerConfig: LoggerConfig = ConfigMapper.mapToLoggerConfig(configProvider.config)
+    const logger = new LoggerService(loggerConfig)
+
+    if (process.listenerCount("unhandledRejection") > 0) {
+      logger.warn(
+        "CommonAppModule",
+        "There is already an 'unhandledRejection' handler, not adding sprinting-retail-common one."
+      )
+    } else {
+      process.on("unhandledRejection", (reason) => {
+        logger.logError(
+          new ServerException("UnhandledRejectionError", "A Promise rejection was not handled.", null, <Error>reason)
+        )
+      })
+    }
+
     return {
       module: CommonAppModule, // needed for dynamic modules
       imports: [ConfigModule.forRoot(configProvider), LoggerModule.forRoot(configProvider)],

--- a/src/appModule/spec/CommonAppModule.spec.ts
+++ b/src/appModule/spec/CommonAppModule.spec.ts
@@ -9,6 +9,10 @@ describe("CommonAppModule", () => {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   beforeAll(async () => {})
 
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   it("should provide an instance of CommonAppModule", async () => {
     const app = await Test.createTestingModule({
       imports: [CommonAppModule.forRoot(TestConfigRaw)],
@@ -17,5 +21,29 @@ describe("CommonAppModule", () => {
     expect(loggerService).toBeInstanceOf(LoggerService)
     const apmHelper = app.get<ApmHelper>(ApmHelper)
     expect(apmHelper).toBeInstanceOf(ApmHelper)
+  })
+
+  it("should subscribe an unhandledRejection handler", async () => {
+    const warnMock = jest.spyOn(LoggerService.prototype, "warn")
+    const countPre = process.listenerCount("unhandledRejection")
+    await Test.createTestingModule({
+      imports: [CommonAppModule.forRoot(TestConfigRaw)],
+    }).compile()
+    const countPost1 = process.listenerCount("unhandledRejection")
+    await Test.createTestingModule({
+      imports: [CommonAppModule.forRoot(TestConfigRaw)],
+    }).compile()
+    const countPost2 = process.listenerCount("unhandledRejection")
+
+    // sometimes the test runner process already has a handler, in that case we are not adding it,
+    // hence the strange .toBeCalledTimes and .toBe clauses
+    expect(warnMock).toBeCalledTimes(countPre > 0 ? 2 : 1)
+    expect(warnMock).toBeCalledWith(
+      "CommonAppModule",
+      "There is already an 'unhandledRejection' handler, not adding sprinting-retail-common one."
+    )
+
+    expect(countPost1).toBe(countPre === 0 ? countPre + 1 : countPre)
+    expect(countPost2).toBe(countPost1)
   })
 })


### PR DESCRIPTION
I don't much like the way the logger is instantiated in this handler but I don't know NestJS well enough to come up with a better solution.
Note that if a handler already exists for this event (unhandledRejection) then the new handler won't be added and a warning is logged.
This might not be the best approach.
Logging could still go wrong (e.g when incorrect parameters are passed into it) but when I wrapped the call with a try/catch block the server process still crashed, so there might be an unhandled promise within the error logging function...