### PR TITLE
Adding uncaughtException handler and truncating lengthy stringified exceptions

### DIFF
--- a/build-local-bifrostnest.sh
+++ b/build-local-bifrostnest.sh
@@ -1,1 +1,1 @@
- tsc --emitDecoratorMetadata && npm pack && cd ../bifrostbackend2/BifrostNest && npm install ../../sprinting-retail-common/sprinting-retail-common-4.0.1.tgz && cd ../../sprinting-retail-common
+tsc --emitDecoratorMetadata && npm pack && cd ../bifrostbackend2/BifrostNest && npm install ../../sprinting-retail-common/sprinting-retail-common-4.3.0.tgz && cd ../../sprinting-retail-common

--- a/src/appModule/CommonAppModule.ts
+++ b/src/appModule/CommonAppModule.ts
@@ -74,17 +74,25 @@ export class CommonAppModule {
       }
     } else {
       process.on("unhandledRejection", (reason) => {
-        try {
           logger.logException(
             "UnhandledRejectionError",
             "A Promise rejection was not handled.",
             undefined,
             <Error>reason
           )
+      }).on('uncaughtException', (reason) => {
+        try {
+          logger.logException(
+            "UncaughtException",
+            "An exception was not caught properly.",
+            undefined,
+            <Error>reason
+          )
         } catch (err) {
           //Suppress errors in error handling
           // eslint-disable-next-line no-console
-          console.log("UnhandledRejectionError", "A Promise rejection was not handled.", reason)
+          console.error("UncaughtException", "An exception was not caught properly.", reason)
+          console.error("UncaughtException", "Failed to log UncaughtException.", err)
         }
       })
     }

--- a/src/errorHandling/exceptions/Exception.ts
+++ b/src/errorHandling/exceptions/Exception.ts
@@ -21,6 +21,7 @@ export interface AppExceptionResponseV2 {
 
 const INSPECT_DEPTH = 7
 const INSPECT_SHOW_HIDDEN = false
+const MSG_LENGTH = 8445 // Max message length for UDP
 
 export class Exception extends Error {
   public readonly errorTraceId: string
@@ -53,6 +54,9 @@ export class Exception extends Error {
           const e0 = util.inspect(this.innerError)
           msg += e0
         }
+      }
+      if (msg.length > MSG_LENGTH) {
+        return msg.substring(0, MSG_LENGTH) + '...TRUNCATED'
       }
       return msg
     } catch (e) {

--- a/src/errorHandling/exceptions/spec/Exception.spec.ts
+++ b/src/errorHandling/exceptions/spec/Exception.spec.ts
@@ -80,6 +80,16 @@ describe("AppException", () => {
       const expectedString = `Exception AMBIGUOUS (HTTP_STATUS 300)`
       expect(exception.toString()).toContain(expectedString)
     })
+
+    it("should truncate messages exceeding max length, and end with truncation note", () => {
+      const maxLength = 8445
+      const errorMessage = Array(maxLength + 1).join('X')
+      const truncateSuffix = '...TRUNCATED'
+      const exception = new Exception(HttpStatus.INTERNAL_SERVER_ERROR, errorMessage)
+      const strException = exception.toString()
+      expect(strException.length).toEqual(maxLength + truncateSuffix.length)
+      expect(strException).toContain(truncateSuffix)
+    })
   })
 
   describe("setInnerError()", () => {


### PR DESCRIPTION
Changes:

1. Truncating stringified exceptions to max length of 8445 characters + 12 characters for truncation note to overcome max message length issue in UDP message logger sends to logstash.

 ```
Error: send EMSGSIZE <IP>:<PORT>
  at doSend (node:dgram:716:16)
  at defaultTriggerAsyncIdScope (node:internal/async_hooks:464:18)
  at afterDns (node:dgram:662:5)
  at processTicksAndRejections (node:internal/process/task_queues:83:21) {
    errno: -40,
    code: ‘EMSGSIZE’,
    syscall: ‘send’,
    address: ‘<IP>',
    port: <PORT>
  }
```

2. Adding process level uncaughtException handler