### PR TITLE
Adding additional data param in event log

### DIFF
--- a/RELEASE_LETTERS.md
+++ b/RELEASE_LETTERS.md
@@ -1,5 +1,11 @@
 <h1>Release letter for sprinting-retail-common</h1>
 
+<h2>Release letter for version 5.1.4</h2>
+
+Breaking changes:
+
+- LoggerService `event` logger now accepts additionalData which takes eventCategory, commonContext, and a new custom message property.
+  event name, data, and category are now part of the log event object instead of serialized message string.
 
 <h2>Release letter for version 5.0.1</h2>
 

--- a/build-local-bifrostnest.sh
+++ b/build-local-bifrostnest.sh
@@ -1,1 +1,1 @@
-tsc --emitDecoratorMetadata && npm pack && cd ../bifrostbackend2/BifrostNest && npm install ../../sprinting-retail-common/sprinting-retail-common-4.4.0.tgz && cd ../../sprinting-retail-common
+npx tsc --emitDecoratorMetadata && npm pack && cd ../bifrostbackend/BifrostNest && npm install ../../sprinting-retail-common/sprinting-retail-common-5.1.4.tgz && cd ../../sprinting-retail-common

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sprinting-retail-common",
-  "version": "4.4.1",
+  "version": "5.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sprinting-retail-common",
-  "version": "5.0.4",
+  "version": "5.1.4",
   "description": "Error handling and logging with APM",
   "contributors": [
     "Nairi Abgaryan",

--- a/src/logger/LoggerService.ts
+++ b/src/logger/LoggerService.ts
@@ -44,10 +44,10 @@ interface LogMessage {
 
 export type ConfigOptions = LoggerConfig
 
-interface CustomEventLog {
-  eventName: string
-  eventCategory?: string
-  eventData: any
+type AdditionalEventData = {
+  eventCategory?: string,
+  commonContext?: ICommonLogContext,
+  message?: string
 }
 
 @Injectable({ scope: Scope.DEFAULT })
@@ -98,31 +98,21 @@ export class LoggerService {
     )
   }
 
-  event(
-    fileName: string,
-    eventName: string,
-    eventData: any,
-    eventCategory?: string,
-    commonContext?: ICommonLogContext
-  ) {
+  event(fileName: string, eventName: string, eventData: any, additionalData?: AdditionalEventData) {
     LoggerService.logger.info(
       this.formatMessage(
         fileName,
         LogLevel.event,
-        this.eventToString({ eventName, eventData, eventCategory }),
+        additionalData?.message || "",
         undefined,
-        eventData,
-        commonContext
+        {
+          ...eventData,
+          name: eventName,
+          ...(additionalData?.eventCategory ? { category: additionalData.eventCategory } : {})
+        },
+        additionalData?.commonContext
       )
     )
-  }
-
-  private eventToString(event: CustomEventLog) {
-    return `EVENT ${event.eventName} ${event.eventCategory ? ` (${event.eventCategory})` : ""} ${util.inspect(
-      event.eventData,
-      false,
-      10
-    )}`
   }
 
   /**

--- a/src/logger/spec/LoggerService.cross-spec.ts
+++ b/src/logger/spec/LoggerService.cross-spec.ts
@@ -14,8 +14,8 @@ describe("logger", () => {
     enableConsoleLogs: true,
     logstash: {
       isUDPEnabled: true,
-      host: process.env.LOGSTASH_HOST,
-      port: parseInt(process.env.LOGSTASH_PORT),
+      host: process.env.LOGSTASH_HOST as string,
+      port: parseInt(process.env.LOGSTASH_PORT as string),
     },
   }
 
@@ -49,6 +49,6 @@ describe("logger", () => {
   })
 
   it("should log events", () => {
-    loggerService.event(__filename, "TestEvent", { tenant: "tid100", tenantId: 100 }, "TestCategory")
+    loggerService.event(__filename, "TestEvent", { tenant: "tid100", tenantId: 100 }, { eventCategory: "TestCategory", message: "Custom test message" })
   })
 })

--- a/src/logger/spec/LoggerService.spec.ts
+++ b/src/logger/spec/LoggerService.spec.ts
@@ -93,4 +93,33 @@ describe("logger", () => {
       loggerService.logError(appException, contextData)
     })
   })
+
+  describe("event", () => {
+    it("should log an event", () => {
+      const spy = jest.spyOn(LoggerService["logger"], "info")
+      loggerService.event(
+        "test-file",
+        "test-event-name",
+        { dummy: "event-data" },
+        { eventCategory: "test-category", message: "test custom message" }
+      )
+      expect(spy).toHaveBeenCalledTimes(1)
+      expect(spy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          filename: "test-file",
+          system: mockConfig.serviceName,
+          component: "test-service",
+          env: mockConfig.env,
+          systemEnv: "test-test-service",
+          logType: LogLevel.event,
+          message: "test custom message",
+          event: {
+            dummy: "event-data",
+            name:"test-event-name",
+            category: "test-category"
+          }
+        })
+      )
+    })
+  })
 })


### PR DESCRIPTION
Changes: LoggerService `event` logger now accepts additionalData which takes eventCategory, commonContext, and a new custom message property. Now event name, data, and category are part of the log event object instead of serialized message string.