### PR TITLE
Improved error handling

### DIFF
--- a/src/appModule/CommonAppModule.ts
+++ b/src/appModule/CommonAppModule.ts
@@ -81,22 +81,25 @@ export class CommonAppModule {
     } else {
       process
         .on("unhandledRejection", (reason) => {
-          logger.logException(
-            "UnhandledRejectionError",
-            "A Promise rejection was not handled.",
-            undefined,
-            <Error>reason
-          )
+          const msg = "A Promise rejection was not handled."
+          // eslint-disable-next-line no-console
+          console.log("UnhandledRejectionError", msg, reason)
+          try {
+            logger.logException("UnhandledRejectionError", msg, undefined, <Error>reason)
+          } catch (err) {
+            // eslint-disable-next-line no-console
+            console.log("Error while trying to report an UnhandledRejectionError", err)
+          }
         })
         .on("uncaughtException", (reason) => {
+          const msg = "An exception was not caught properly."
+          // eslint-disable-next-line no-console
+          console.log("UncaughtException", msg, reason)
           try {
-            logger.logException("UncaughtException", "An exception was not caught properly.", undefined, <Error>reason)
+            logger.logException("UncaughtException", msg, undefined, <Error>reason)
           } catch (err) {
-            //Suppress errors in error handling
             // eslint-disable-next-line no-console
-            console.error("UncaughtException", "An exception was not caught properly.", reason)
-            // eslint-disable-next-line no-console
-            console.error("UncaughtException", "Failed to log UncaughtException.", err)
+            console.log("Error while trying to report an UncaughtException", err)
           }
         })
     }


### PR DESCRIPTION
In case of errors during the startup of the application, we may end up with errors reaching the global error handlers. I think it is wise to be extra verbose in this case, hence logging to both the logger and to the console. Also, error in the error handling should be logged more clearly. 