### PR TITLE
Make the event data more compact 

### DIFF
--- a/src/logger/LoggerService.ts
+++ b/src/logger/LoggerService.ts
@@ -141,7 +141,7 @@ export class LoggerService {
         domain: eventDomain,
         data: eventData,
       },
-      message: message || `${eventName} ${JSON.stringify(eventData)}`, //message + (data ? ` ${util.inspect(data, false, 10)}` : ""),
+      message: message || eventName,
     }
     if (context) {
       logMessage.context = {

--- a/src/logger/spec/LoggerService.spec.ts
+++ b/src/logger/spec/LoggerService.spec.ts
@@ -121,7 +121,7 @@ describe("LoggerService", () => {
       filename: "test-file",
       "log.level": "info",
       logType: "event",
-      message: 'SomeEvent {"someKey":"someValue"}',
+      message: "SomeEvent",
       system: PrincipalEnum.TestSystemName,
       systemEnv: `test-${PrincipalEnum.TestSystemName}`,
       event: {


### PR DESCRIPTION
Make the event data more compact so it is not lost due to length exceeding. 

Motivation: I lost some ELK events containing recording of AI conversation due to the length of the log record. This change will make the message field only contain the event name instead of a full concatenation of the event. 