### PR TITLE
improve-error-handling-for-security-errors

### DIFF
--- a/RELEASE_LETTERS.md
+++ b/RELEASE_LETTERS.md
@@ -1,5 +1,38 @@
 <h1>Release letter for sprinting-retail-common</h1>
 
+<h2>Release letter for version 6.1.0</h2>
+
+- Changed handling of SecurityException's to have this http response in non-prod:
+
+```
+{
+          "contextData": {
+            "key": "value",
+          },
+          "debugMessage": "SecurityException(ERROR_NAME: SecurityException | HTTP_STATUS: 403 | ERR_ID: xxx | ERROR_DESCRIPTION: Description | CONTEXT_DATA: { key: 'value' }) ",
+          "errorName": "SecurityException",
+          "errorTraceId": "xxx",
+          "httpStatus": 403,
+          "message": "Description",
+          "stacktrace": Any<String>,
+        }
+```
+
+and this http response in prod:
+
+```
+        {
+          "errorName": "SecurityException",
+          "errorTraceId": "xxx",
+          "httpStatus": 403,
+          "note": "Error details can be looked up in Kibana",
+        }
+```
+
+<h2>Release letter for version 6.0.12</h2>
+
+- Fixed an issue in error handling when certain properties were undefined
+
 <h2>Release letter for version 6.0.11</h2>
 
 - Improved handling of HttpException errors from Nest making sure all relevant error details are correctly logged to console, ELK and http response
@@ -7,7 +40,7 @@
 <h2>Release letter for version 6.0.5 -> 6.0.10</h2>
 
 - Various changes related to seeding
-- Improved handling of the case where no environment is specified and we will default to envPrefix z. 
+- Improved handling of the case where no environment is specified and we will default to envPrefix z.
 
 <h2>Release letter for version 6.0.5</h2>
 
@@ -17,17 +50,18 @@
 
 - Adding custom message support in event logger using LoggerService
 
-
 <h2>Release letter for version 6.0.3</h2>
 
 - Changing the environment names in application logs so that it is, say, p-personserviceapi instead of p-env-personserviceapi
 
 <h2>Release letter for version 6.0.2</h2>
 
-Breaking changes: 
+Breaking changes:
+
 - LoggerService.event() is fixed not. At the same time the signature of this function has been altered.
 
-Other changes: 
+Other changes:
+
 - The env-suffix issue has been solved. Meaning, the index in ELK is now properly named so instead of p-env-bifrostbackend* it would be called p-bifrostbackend*
 
 <h2>Release letter for version 5.2.0</h2>
@@ -38,8 +72,8 @@ Other changes:
 
 <h2>Release letter for version 5.1.5</h2>
 
-- Improving error reporting by adding messages from inner errors to the field in ELK called error.exception.message. This makes more details from the errors searchable. 
-- Improving error reporting by preserving the original stacktrace so that errors can be clearly understood. 
+- Improving error reporting by adding messages from inner errors to the field in ELK called error.exception.message. This makes more details from the errors searchable.
+- Improving error reporting by preserving the original stacktrace so that errors can be clearly understood.
 
 <h2>Release letter for version 5.1.4</h2>
 
@@ -54,8 +88,8 @@ Multiple breaking changes were made here.
 
 - ApmHelper is now implemented as a traditional singleton pattern to make it work better with NestJS DI. It has these
   consequences:
-    - All functions on the ApmHelper such as startSpan() is now normal methods, not static functions. Hence you need to
-      change code such as ApmHelper.startSpan() to ApmHelper.Instance.startSpan().
+  - All functions on the ApmHelper such as startSpan() is now normal methods, not static functions. Hence you need to
+    change code such as ApmHelper.startSpan() to ApmHelper.Instance.startSpan().
 
 <h2>Release letter for version 4.5.0</h2>
 
@@ -64,8 +98,8 @@ Multiple breaking changes were made here.
 <h2>Release letter for version 4.4.1</h2>
 
 - We now support process.env.NODE_ENV to either include the "-env" or not meaning that both of these will work:
-    - NODE_ENV=d
-    - NODE_ENV=d-env
+  - NODE_ENV=d
+  - NODE_ENV=d-env
 
 <h2>Release letter for version 4.4.0</h2>
 
@@ -149,8 +183,7 @@ Multiple breaking changes were made here.
 - Adding support for context data in logs.
 - Adding support of custom events in logs.
 
-<h2>Release letter for version 2.5.0</h2>
-- 
+## <h2>Release letter for version 2.5.0</h2>
 
 - Simplify stacktrace generation to make sure stacktraces are clickable in the IDEs
 
@@ -189,3 +222,6 @@ Breaking changes:
 
 - apmSamplingRate has changed name to transactionSampleRate
 
+```
+
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sprinting-retail-common",
-  "version": "6.0.13",
+  "version": "6.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sprinting-retail-common",
-      "version": "6.0.13",
+      "version": "6.1.0",
       "license": "MIT",
       "dependencies": {
         "@elastic/ecs-winston-format": "1.5.0",
@@ -2329,12 +2329,12 @@
       }
     },
     "node_modules/braces": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
       "dev": true,
       "dependencies": {
-        "fill-range": "^7.0.1"
+        "fill-range": "^7.1.1"
       },
       "engines": {
         "node": ">=8"
@@ -3496,9 +3496,9 @@
       }
     },
     "node_modules/fill-range": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
       "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sprinting-retail-common",
-  "version": "6.0.13",
+  "version": "6.1.0",
   "description": "Error handling and logging with APM",
   "contributors": [
     "Nairi Abgaryan",

--- a/src/config/interface/EnvironmentConfig.ts
+++ b/src/config/interface/EnvironmentConfig.ts
@@ -2,3 +2,8 @@ export interface EnvironmentConfig {
   isProduction: boolean
   envPrefix: string
 }
+
+export function isProduction() {
+  // We use the convention that all variations of p-, p{number}- and production are considered production environments
+  return process.env.NODE_ENV && process.env.NODE_ENV.charAt(0) === "p"
+}

--- a/src/config/interface/RetailCommonConfigConvict.ts
+++ b/src/config/interface/RetailCommonConfigConvict.ts
@@ -2,25 +2,21 @@ import convict from "convict"
 import { ClientException } from "../../errorHandling/exceptions/ClientException"
 import * as validators from "convict-format-with-validator"
 import { IApmConfig } from "./IApmConfig"
+import { isProduction } from "./EnvironmentConfig"
 
 convict.addFormat(validators.url)
-
-function isProd() {
-  // We use the convention that all variations of p-, p{number}- and production are considered production environments
-  return process.env.NODE_ENV && process.env.NODE_ENV.charAt(0) === "p"
-}
 
 export const DEFAULT_APM_CONFIG = (): IApmConfig =>
   Object.freeze({
     serviceName: undefined,
     serverUrl: undefined,
-    transactionSampleRate: isProd() ? 0.1 : 1,
+    transactionSampleRate: isProduction() ? 0.1 : 1,
     captureExceptions: false,
     centralConfig: false,
     metricsInterval: "10s",
     captureErrorLogStackTraces: "messages",
-    captureBody: isProd() ? "errors" : "all",
-    captureHeaders: !isProd(),
+    captureBody: isProduction() ? "errors" : "all",
+    captureHeaders: !isProduction(),
     enableLogs:
       process.env.ENABLE_LOGS === "true" || process.env.ENABLE_LOGS === "1" || process.env.ENABLE_LOGS === "yes",
   })

--- a/src/errorHandling/exceptions/SecurityException.ts
+++ b/src/errorHandling/exceptions/SecurityException.ts
@@ -1,4 +1,4 @@
-import { Exception, ExceptionHttpResponse } from "./Exception"
+import { Exception } from "./Exception"
 import { HttpStatus } from "@nestjs/common"
 
 /**
@@ -15,16 +15,5 @@ export class SecurityException extends Exception {
   ) {
     super(HttpStatus.FORBIDDEN, "SecurityException", description, contextData, innerError)
     Object.setPrototypeOf(this, SecurityException.prototype)
-  }
-
-  /**
-   * Make sure details about security errors are never returned to the client.
-   */
-  override getResponse(): ExceptionHttpResponse {
-    return {
-      httpStatus: this.httpStatus,
-      errorName: this.errorName,
-      errorTraceId: this.errorTraceId,
-    }
   }
 }


### PR DESCRIPTION
This PR will change how SecurityExceptions are serialised into a http response. With this PR, we will have all details in non-prod (to ensure a good developer experience) and no details in production for security reasons. Before this change, security-related errors had all details hidden when serialised into a http response which created a bad developer experience. 